### PR TITLE
fix: find_parent in union_set

### DIFF
--- a/For C++/Graph/Weighted/Kruskal/Kruskal.cpp
+++ b/For C++/Graph/Weighted/Kruskal/Kruskal.cpp
@@ -1,21 +1,25 @@
 #include <bits/stdc++.h>
 using namespace std;
 
-struct graph{
+struct graph
+{
     long vertexCount, edgeCount;
     vector<vector<pair<long, long>>> adjList;
     vector<pair<long, pair<long, long>>> edgeList;
-    
-    void init(long v){
+
+    void init(long v)
+    {
         vertexCount = v;
         edgeCount = 0;
 
-        for(int i=0; i<vertexCount; i++){
+        for (int i = 0; i < vertexCount; i++)
+        {
             adjList.push_back({}); // inserts V ammount of empty vector
         }
     }
 
-    void add_edge(long vertex1, long vertex2, long weight){
+    void add_edge(long vertex1, long vertex2, long weight)
+    {
         adjList[vertex1].push_back(make_pair(vertex2, weight));
         adjList[vertex2].push_back(make_pair(vertex1, weight));
 
@@ -23,7 +27,8 @@ struct graph{
         edgeCount++;
     }
 
-    void dfs(vector<long> &result, long start){
+    void dfs(vector<long> &result, long start)
+    {
         vector<bool> visited(vertexCount, false);
         stack<long> st;
 
@@ -31,23 +36,27 @@ struct graph{
         visited[start] = true;
         result.push_back(start);
 
-        while(!st.empty()){
+        while (!st.empty())
+        {
             long temp = st.top();
             st.pop();
 
-            if(!visited[temp]){
+            if (!visited[temp])
+            {
                 result.push_back(temp);
                 visited[temp] = true;
             }
 
-            for(auto vertex:adjList[temp]){
+            for (auto vertex : adjList[temp])
+            {
                 if (!visited[vertex.first])
                     st.push(vertex.first);
             }
         }
     }
 
-    void bfs(vector<long> &result, long start){
+    void bfs(vector<long> &result, long start)
+    {
         vector<bool> visited(vertexCount, false);
         queue<long> q;
 
@@ -55,12 +64,15 @@ struct graph{
         visited[start] = true;
         result.push_back(start);
 
-        while(!q.empty()){
+        while (!q.empty())
+        {
             long temp = q.front();
             q.pop();
 
-            for(auto vertex:adjList[temp]){
-                if (!visited[vertex.first]){
+            for (auto vertex : adjList[temp])
+            {
+                if (!visited[vertex.first])
+                {
                     q.push(vertex.first);
                     visited[vertex.first] = true;
                     result.push_back(vertex.first);
@@ -69,29 +81,35 @@ struct graph{
         }
     }
 
-    void dijkstra(vector<long> &result, long start){
+    void dijkstra(vector<long> &result, long start)
+    {
         vector<bool> visited(vertexCount, false);
-        priority_queue <pair<long, long>, 
-                        vector <pair<long, long>>, 
-                        greater <pair<long, long>> > pq;
+        priority_queue<pair<long, long>,
+                       vector<pair<long, long>>,
+                       greater<pair<long, long>>>
+            pq;
         result = vector<long>(vertexCount, LONG_MAX);
-        
+
         pq.push(make_pair(0, start));
         result[start] = 0;
 
-        while(!pq.empty()){
+        while (!pq.empty())
+        {
             auto temp = pq.top();
             pq.pop();
 
-            if(visited[temp.second]) continue;
+            if (visited[temp.second])
+                continue;
 
             visited[temp.second] = true;
 
-            for(auto vertex:adjList[temp.second]){
+            for (auto vertex : adjList[temp.second])
+            {
                 long nextVertex = vertex.first;
                 long weight = vertex.second;
 
-                if(temp.first + weight < result[nextVertex]) {
+                if (temp.first + weight < result[nextVertex])
+                {
                     result[nextVertex] = temp.first + weight;
                     pq.push(make_pair(result[nextVertex], nextVertex));
                 }
@@ -99,35 +117,48 @@ struct graph{
         }
     }
 
-    long find_parent(vector<long> &parent, long v){
-        if(v == parent[v]) return v;
+    long find_parent(vector<long> &parent, long v)
+    {
+        if (v == parent[v])
+            return v;
 
-        return find_parent(parent, parent[v]);
+        return parent[v] = find_parent(parent, parent[v]);
     }
 
-    void union_set(vector<long> &parent, long vertex1, long vertex2){
-        parent[vertex2] = parent[vertex1];
+    void union_set(vector<long> &parent, long vertex1, long vertex2)
+    {
+        int parent1 = find_parent(parent, vertex1);
+        int parent2 = find_parent(parent, vertex2);
+
+        if (parent1 != parent2)
+            parent[vertex2] = parent[vertex1];
     }
 
-    void kruskal(vector<pair<long, pair<long, long>>> &result){
+    void kruskal(vector<pair<long, pair<long, long>>> &result)
+    {
         vector<long> parent;
-        for(int i=0; i<vertexCount; i++) parent.push_back(i);
+        for (int i = 0; i < vertexCount; i++)
+            parent.push_back(i);
 
         sort(edgeList.begin(), edgeList.end());
-        
-        for(auto edge:edgeList){
+
+        for (auto edge : edgeList)
+        {
             long vertex1 = edge.second.first;
             long vertex2 = edge.second.second;
-            if(find_parent(parent, vertex1) != find_parent(parent, vertex2)){
+            if (find_parent(parent, vertex1) != find_parent(parent, vertex2))
+            {
                 result.push_back(edge);
                 union_set(parent, vertex1, vertex2);
-                if(result.size() == vertexCount-1) return;
+                if (result.size() == vertexCount - 1)
+                    return;
             }
         }
     }
 };
 
-int main(){
+int main()
+{
     graph g;
     g.init(5);
     g.add_edge(0, 1, 4);
@@ -142,7 +173,8 @@ int main(){
 
     g.kruskal(kruskal_result);
 
-    for(auto it:kruskal_result){
+    for (auto it : kruskal_result)
+    {
         cout << it.first << " " << it.second.first << " " << it.second.second << endl;
     }
 


### PR DESCRIPTION
there are two problems I encountered from `For C++/Graph/Weighted/Kruskal/Kruskal.cpp`

1. `find_parent()` function is not optimized

to optimize `find_parent()`, we can store and update the value of `parent[v]` to `find_parent(parent, v)`

2. `union_set()` function 

since our `union_set()` function is like:

```cpp
    void union_set(vector<long> &parent, long vertex1, long vertex2)
    {
        parent[vertex2] = parent[vertex1];
    }
```

hence, we must ensure that each `vertex2` and `vertex1` is a parent of their "colony". thus, we can modify the `union_set` to:

```cpp
    void union_set(vector<long> &parent, long vertex1, long vertex2)
    {
        int parent1 = find_parent(parent, vertex1);
        int parent2 = find_parent(parent, vertex2);

        if (parent1 != parent2)
            parent[vertex2] = parent[vertex1];
    }
```

we can find each parent from those vertexes. if they have different parents, we can merge them into single set